### PR TITLE
103997166 chore build circle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.DS_Store
+.tmp
+.sass-cache
+.cache/
+.bundle
+/dist/
+/docs/
+*.sublime-project
+*.sublime-workspace
+/node_modules/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
 # Angular.js Modules
+
+This repository holds Angular.js modules that can be used to build Southbank Centre websites and apps.
+
+In particular, the modules are designed for apps that consume data from the Southbank Centre Web Content service, although this isn’t a requirement.
+
+## Installing a module
+
+1. Install bower if you haven't already: `$ npm install -g bower`
+2. Install angularjs-modules into your app: `$ bower install --save Southbank-Centre/angularjs-modules`. See the [bower documentation](http://bower.io) for options related to installing a specific release or branch of the repo.
+3. Add script tags to include whichever version of whichever modules you want to use in your app. E.g. `<script src="bower_components/angularjs-modules/scContent/0.1.2/release/scContent.min.js"></script>`
+
+## Installing a new version of a module
+
+1. Run `$ bower install --save Southbank-Centre/angularjs-modules` again in your app. The latest version of the module will be included in the angularjs-modules package and you will be able to include it's script file in you app.
+
+## Module design principles
+
+1. A module should serve a single well-defined purpose, and should not provide any other logic beyond what is needed to serve that purpose.
+2. A module should provide functionality without making assumes about the app it is being used by.
+3. A module should not provide layout or styling logic unless that is their specific purpose.
+4. Smaller is better, although a module should only been created if there is a good chance it will be useful for another site or app.
+5. Module code should be developed according to the John Papa style guide.
+
+See [this diagram](https://drive.google.com/open?id=0B6MjeYJdf0YIQ1NnWDR2aE9Lam8) for an understanding of how modules might be structured.
+
+## Running tests
+
+### Unit tests
+
+1. Install karma-cli globally: `$ npm install -g karma-cli`
+2. Install dependencies: `$ npm install`
+3. Run karma. From the `test/unit` directory run `$ karma start karma.conf.js --single-run`
+
+You can run karma and have it run tests when your test files change. From the `test/unit` directory run `$ karma start karma.conf.js`

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,11 @@
+{
+  "name": "angularjs-modules",
+  "ignore": [
+    "**/.*",
+    "*/*/app",
+    "*/*/node_modules",
+    "*/*/package.json",
+    "*/*/Gruntfile.js",
+    "test"
+  ]
+}

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,24 @@
+machine:
+  environment:
+    SAUCE_TUNNEL_ID: circle-angularjsmodules-$CIRCLE_BUILD_NUM
+
+dependencies:
+
+  override:
+    - npm install
+
+  post:
+    # karma setup
+    - npm install -g karma-cli
+
+test:
+  override:
+    - karma start karma.conf.js --single-run:
+        pwd:
+          test/unit
+
+general:
+  branches:
+    ignore:
+      # add your branch name here if you don't want it to build in CircleCI
+      - do_not_build_this_branch

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "angularjs-modules-unit-tests",
+  "dependencies": {
+    "angular": "^1.4.5",
+    "angular-mocks": "^1.4.5",
+    "angular-ui-router": "^0.2.15",
+    "karma": "^0.12.24",
+    "karma-jasmine": "^0.1.5",
+    "karma-mocha-reporter": "^1.1.1",
+    "karma-phantomjs-launcher": "^0.1.4",
+    "karma-sinon": "^1.0.4",
+    "sinon": "^1.16.1"
+  }
+}

--- a/test/unit/karma.conf.js
+++ b/test/unit/karma.conf.js
@@ -1,0 +1,75 @@
+// Karma configuration
+// http://karma-runner.github.io/0.12/config/configuration-file.html
+
+module.exports = function(config) {
+    'use strict';
+
+    config.set({
+        // enable / disable watching file and executing tests whenever any file changes
+        autoWatch: true,
+
+        // base path, that will be used to resolve files and exclude
+        basePath: '../../',
+
+        // testing framework to use (jasmine/mocha/qunit/...)
+        frameworks: ['jasmine', 'sinon'],
+
+        // list of files / patterns to load in the browser
+        files: [
+            // bower components and app files should also be included here
+            'node_modules/angular/angular.min.js',
+            'node_modules/angular-mocks/angular-mocks.js',
+            'node_modules/angular-ui-router/release/angular-ui-router.min.js',
+            'sc*/*/release/**/*.min.js',
+            'sc*/*/release/**/*.html',
+            'test/unit/specs/**/*.js'
+        ],
+
+        // list of files / patterns to exclude
+        exclude: [],
+
+        // web server port
+        port: 9990,
+
+        // Start these browsers, currently available:
+        // - Chrome
+        // - ChromeCanary
+        // - Firefox
+        // - Opera
+        // - Safari (only Mac)
+        // - PhantomJS
+        // - IE (only Windows)
+        browsers: [
+            'PhantomJS'
+        ],
+
+        // Which plugins to enable
+        plugins: [
+            'karma-phantomjs-launcher',
+            'karma-jasmine',
+            'karma-mocha-reporter',
+            'karma-sinon'
+        ],
+
+        reporters: [
+            'mocha'
+        ],
+
+        // Continuous Integration mode
+        // if true, it capture browsers, run tests and exit
+        singleRun: false,
+
+        colors: true,
+
+        // level of logging
+        // possible values: LOG_DISABLE || LOG_ERROR || LOG_WARN || LOG_INFO || LOG_DEBUG
+        logLevel: config.LOG_INFO,
+
+        // Uncomment the following lines if you are using grunt's server to run the tests
+        // proxies: {
+        //   '/': 'http://localhost:9000/'
+        // },
+        // URL root prevent conflicts with the site root
+        // urlRoot: '_karma_'
+    });
+};


### PR DESCRIPTION
This branch won't build in CI because there are no tests. To show that CI will build this repo once there are tests to run, I've rebuild the `101583246_frontend_modules` branch, branching it from this one so that you can see the branch building successfully in CI.

This PR also adds some of the basic files to the repo, including bower and npm package files to define respective apps with dependencies. It also includes information about the repo in the README file.